### PR TITLE
Support 180 degree display rotation

### DIFF
--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -288,8 +288,15 @@ async fn main(spawner: Spawner) {
             DMA_CHx: peripherals.DMA_CH2,
         };
 
+        // Deg90 vs Deg270 is a 180 flip - same 480x320 geometry, and the touch orientation follows
+        // the rotation inside the board driver, so nothing downstream needs to change.
+        let display_rotation = if framework.borrow_mut().display_flip_from_flash() {
+            mipidsi::options::Rotation::Deg90
+        } else {
+            mipidsi::options::Rotation::Deg270
+        };
         let display_orientation = mipidsi::options::Orientation::new()
-            .rotate(mipidsi::options::Rotation::Deg270)
+            .rotate(display_rotation)
             .flip_horizontal();
 
         WT32SC01Plus::new(display_peripherals, sdcard_peripherals, display_orientation, framework.clone())

--- a/core/static/config.html
+++ b/core/static/config.html
@@ -174,6 +174,16 @@
         />
       </div>
 
+      <div class="form-row">
+        <div style="display: flex; align-items: center; gap: 6px;">
+          <input type="checkbox" id="display-flip" />
+          <label for="display-flip" style="margin: 0;"
+            >Rotate Screen 180&deg;</label
+          >
+        </div>
+        <span>For upside-down mounting. Takes effect after a restart.</span>
+      </div>
+
       <button
         id="display-section-apply"
         type="button"
@@ -656,6 +666,7 @@ ProtoPasta 500g - Cardboard - 84g,84"
             data.dimming_percent;
           document.getElementById("blackout-timeout").value =
             data.blackout_timeout;
+          document.getElementById("display-flip").checked = data.flip;
         }
       }
 
@@ -719,7 +730,13 @@ ProtoPasta 500g - Cardboard - 84g,84"
         const blackout_timeout = parseInt(
           document.getElementById("blackout-timeout").value,
         );
-        const data = { dimming_timeout, dimming_percent, blackout_timeout };
+        const flip = document.getElementById("display-flip").checked;
+        const data = {
+          dimming_timeout,
+          dimming_percent,
+          blackout_timeout,
+          flip,
+        };
         const applyButton = document.getElementById("display-section-apply");
         sendConfigData("/api/display-config", data, applyButton); // Replace with actual server endpoint
       }


### PR DESCRIPTION
Upside down mounting for RFID reader on opposite side

For compact mounts without a lot of space avoiding the power plug on the same side as the RFID reader is quite useful, but requires rotation support.