### PR TITLE
feat: Support stocks going to zero

### DIFF
--- a/core/src/spool_record.rs
+++ b/core/src/spool_record.rs
@@ -79,6 +79,9 @@ pub struct SpoolRecord {
     pub spools_count: i32,
     #[serde(default, deserialize_with = "deserialize_optional")]
     pub td: Option<f32>,
+    // Explicit record type. Appended last so older records (which lack the column) still parse.
+    #[serde(default, serialize_with = "serialize_optional_bool_yn", deserialize_with = "deserialize_optional_bool_yn")]
+    pub stock: Option<bool>,
     // !!! Don't Forget to set default for any field!
     // pub update_time
     // pub update_tag_fields_time
@@ -181,6 +184,12 @@ const TAG_URL_PREFIX_S1: &str = "https://tag.spoolease.io/S1/"; // starting 0.6.
 impl SpoolRecord {
     pub fn linked_tag_ids(&self) -> impl Iterator<Item = &str> {
         self.tag_id.iter().map(String::as_str).filter(|tag_id| !tag_id.is_empty())
+    }
+    /// Returns true if this record represents a stock/bulk group rather than an individual physical spool.
+    /// A stock record may hold any number of spools, including 0 (nothing spare on hand right now) and 1.
+    /// Records written before `stock` existed have no flag, and fall back to the old rule (`spools_count > 1`).
+    pub fn is_stock(&self) -> bool {
+        self.stock.unwrap_or(self.spools_count > 1)
     }
 
     pub fn to_tag_descriptor_s1(&self, filament_sup_info: &Option<FilamentSupInfo>) -> Option<String> {

--- a/core/src/store.rs
+++ b/core/src/store.rs
@@ -531,6 +531,7 @@ impl Store {
                         actual_location: spool_record.actual_location.clone(),
                         spools_count: spool_record.spools_count,
                         td: spool_record.td,
+                        stock: spool_record.stock,
                     }
                 } else {
                     return Err(StoreError::NotFound { id: spool_record.id.clone() });

--- a/core/src/view_model.rs
+++ b/core/src/view_model.rs
@@ -1820,7 +1820,7 @@ impl ViewModel {
 
     fn ui_load_staging(&self, spool_id: &str) -> SharedString {
         if let Some(spool_rec) = self.store.get_spool_by_id(spool_id) {
-            if spool_rec.spools_count <= 1 {
+            if ! spool_rec.is_stock() {
                 self.filament_staging.borrow_mut().set_spool_record(spool_rec, StagingOrigin::Scanned);
                 self.filament_staging.borrow_mut().set_scanned_tag_id(None);
                 self.display_filament_staging(true);
@@ -2099,7 +2099,7 @@ impl ViewModel {
 
     fn ui_can_link_untagged_spool_to_tag(&self, id: &str) -> SharedString {
         if let Some(spool_rec) = self.store.get_spool_by_id(id) {
-            if spool_rec.spools_count <= 1 {
+            if !spool_rec.is_stock() {
                 if !spool_rec.has_valid_tag_id() {
                     SharedString::new()
                 } else {
@@ -2115,7 +2115,7 @@ impl ViewModel {
 
     fn ui_can_link_tagged_spool_to_tag(&self, id: &str) -> SharedString {
         if let Some(spool_rec) = self.store.get_spool_by_id(id) {
-            if spool_rec.spools_count <= 1 {
+            if !spool_rec.is_stock() {
                 if spool_rec.has_valid_tag_id() {
                     SharedString::new()
                 } else {
@@ -2659,7 +2659,7 @@ impl ViewModel {
             let ui = view_model.borrow().ui_weak.unwrap();
             let ui_app_state = ui.global::<crate::app::AppState>();
 
-            if spool_rec.spools_count > 1 {
+            if spool_rec.is_stock() {
                 ui_app_state.invoke_link_tag_to_spool_id_status("Can't link Stock".into());
                 return;
             }

--- a/core/src/web_app.rs
+++ b/core/src/web_app.rs
@@ -890,17 +890,28 @@ async fn handle_spools_add_edit(key: &'static RefCell<Vec<u8>>, state: ConsoleAp
     let store = state.store;
     let mut split_spool = None;
 
+    // Clients before the explicit `stock` flag identified stock by count alone, so fall back to that rule.
+    let is_stock_record = add_spool.stock.unwrap_or(add_spool.spools_count > 1);
+    if is_stock_record {
+        if add_spool.spools_count < 0 {
+            return format!("Stock count can't be negative ({})", add_spool.spools_count);
+        }
+    } else if add_spool.spools_count != 1 {
+        return format!("A spool record holds exactly 1 spool, got {}", add_spool.spools_count);
+    }
     if let Some(split_id) = add_spool.split
         && let Some(splitted_spool) = store.get_spool_by_id(&split_id)
     {
-        if splitted_spool.spools_count - add_spool.spools_count < 1 {
+        if !splitted_spool.is_stock() {
+            return format!("Spool {split_id} isn't a stock record and can't be split");
+        }
+        if add_spool.spools_count < 1 || splitted_spool.spools_count - add_spool.spools_count < 0 {
             return format!(
                 "Spool {split_id} had {} and can't split out {}",
                 splitted_spool.spools_count, add_spool.spools_count
             );
-        } else {
-            split_spool = Some(splitted_spool);
         }
+        split_spool = Some(splitted_spool);
     }
 
     let color_code = add_spool
@@ -950,6 +961,7 @@ async fn handle_spools_add_edit(key: &'static RefCell<Vec<u8>>, state: ConsoleAp
         actual_location: add_spool.actual_location,
         spools_count: add_spool.spools_count,
         td: add_spool.td.filter(|td| td.is_finite() && *td >= 0.0),
+        stock: Some(is_stock_record),
     };
 
     let spool_id = if add_spool_operation {
@@ -989,6 +1001,8 @@ async fn handle_spools_add_edit(key: &'static RefCell<Vec<u8>>, state: ConsoleAp
     if let Some(mut split_spool) = split_spool {
         let split_spool_id = split_spool.id.clone();
         split_spool.spools_count -= add_spool.spools_count;
+        // The remainder stays stock even when it drops to 1 or 0, so stamp the flag on legacy records too.
+        split_spool.stock = Some(true);
         if let Err(err) = store.update_spool(split_spool, None).await {
             error!("Critical: Added new splitted spool/stock but failed to update splitted stock : {err}");
             return err.to_string();
@@ -1890,6 +1904,8 @@ pub struct AddSpoolDTO {
     pub assigned_location: String,
     pub actual_location: String,
     pub spools_count: i32,
+    #[serde(default)]
+    pub stock: Option<bool>,
     pub split: Option<String>,
     pub added_time: Option<i32>,
     #[serde(default)]


### PR DESCRIPTION
A proof of concept consideration for supporting stocks going to zero.   Right now, as the # of spools is used to determine if something is a stock we have a requirement that a user have at least two spare of a spool before they can use stocks.    I think stocks have a great analog. I  have open spools in use and then spare boxes of extras that have not had rfid tags scanned/added.   I think it makes sense for stocks to be first class tracking for those who want it.

Under the existing workflow I have a black spool in use, chip fully scanned its assigned to its shelf/rack/location.    Then I have three spare boxes of black NIB these are all together in their own location, no chip scanned but a stock is created in spoolease tracking them.

This works nicely, in the UI the spare boxes are clearly separated from the normal tracked spools and its obvious whats going on.

Now I go to use one of those stocks,  no problem I split it off scan the rfid tag and continue along.   Except then I go to use another, this leaves me with only one spare stock.   At this point the spare stock is converted to a spool as well but untagged as I am not opening it.   This is due to the technical limitation above but arbitrary from a user perspective.   This also leads to the odd situation of when I get more black in, I can't just go increase my stocks level once it goes below 2 because its now a spool again so I need to find the one untagged one, change it back into a stock, then add the number of new rolls to the quantity minus one (as it already made quantity two going back to stock).   

It also allows one to quickly look at just stocks if needing to order more rolls to determine what items you keep spares on that you are low/out of.

This upgrades stocks to be first class types that are allowed to have any quantity.  I added a field to the table but this could be avoided by doing something like using negative numbers for stocks if desired.   

It requires changes to the PWA as well: https://page.ghfs.workers.dev/spoolease_stocks_to_zero

but making a request on the minified source seems not super useful.

I would have just submitted this as an idea, but as I wanted the feature figured include the code I used.  Obviously if you think its worthwhile and prefer to implement another way by all means:)