### PR TITLE
Add NFC Scan Support

### DIFF
--- a/core/src/web_app.rs
+++ b/core/src/web_app.rs
@@ -36,9 +36,9 @@ use serde::{Deserialize, Serialize};
 use shared::gcode_analysis_task::Fetch3mf;
 
 use crate::app_config::{
-    AiProviderAvailability, AiProviderId, ApiTokenMetadata, AppConfig, BackupConfig, BackupStatus, BambuPrinterConfig, DefaultPrinterConfig,
-    DeviceCertificateGenerationRequest, DeviceCertificateLeafRequest, DeviceCertificateStatus, FILAMENT_BRAND_NAMES, FakePrinterConfig,
-    PrinterConfig, PrinterDriverConfig, PrinterMode, PrintersConfig, SPOOLS_CATALOG, ScaleConfig, ScaleSourceConfig, UseAmsScan,
+    AiProviderAvailability, AiProviderId, ApiTokenMetadata, AppConfig, BAMBU_COLOR_NAMES, BackupConfig, BackupStatus, BambuPrinterConfig,
+    DefaultPrinterConfig, DeviceCertificateGenerationRequest, DeviceCertificateLeafRequest, DeviceCertificateStatus, FILAMENT_BRAND_NAMES,
+    FakePrinterConfig, PrinterConfig, PrinterDriverConfig, PrinterMode, PrintersConfig, SPOOLS_CATALOG, ScaleConfig, ScaleSourceConfig, UseAmsScan,
 };
 use crate::bambu::bambu_api::PrintCommand;
 use crate::bambu::calibration::KInfo;
@@ -183,6 +183,13 @@ impl NestedAppWithWebAppState<ConsoleAppState> for ConsoleWebService {
             }),
             (ApiMethod::Get, "/filament-brands") => box_route_future!({
                 picoserve::response::File::with_content_type("text/plain; charset=utf-8", FILAMENT_BRAND_NAMES.as_bytes())
+                    .call_request_handler_service(state, (), request, response_writer)
+                    .await
+            }),
+            // Same catalog `BambuLabTag::to_spool_rec` names colors from, so the web app can resolve a
+            // scanned manufacturer tag to the identical "Name (code)" the console would have written.
+            (ApiMethod::Get, "/bambu-color-names") => box_route_future!({
+                picoserve::response::File::with_content_type("text/plain; charset=utf-8", BAMBU_COLOR_NAMES.as_bytes())
                     .call_request_handler_service(state, (), request, response_writer)
                     .await
             }),
@@ -911,14 +918,27 @@ async fn handle_spools_add_edit(key: &'static RefCell<Vec<u8>>, state: ConsoleAp
         .map(|c| c.to_string())
         .collect::<Vec<_>>();
 
+    // Tag ids arrive `;`-separated, same as the CSV store encodes them, so the web client can
+    // manage secondary tags without a physical scan. Stored ids are upper-case hex (see
+    // `hex::encode_upper` in the scan path), so normalize before comparing against the index.
+    let mut tag_id: Vec<String> = Vec::new();
+    for tag in add_spool.tag_id.split(';').map(str::trim).filter(|tag| !tag.is_empty()) {
+        let tag = tag.to_uppercase();
+        if tag_id.contains(&tag) {
+            continue;
+        }
+        if let Some(other_spool_id) = store.get_spool_id_by_tag_id(&tag)
+            && other_spool_id != add_spool.id
+        {
+            return format!("Tag {tag} is already linked to spool {other_spool_id}");
+        }
+        tag_id.push(tag);
+    }
+
     let add_spool_operation = add_spool.id.is_empty();
     let new_spool = SpoolRecord {
         id: add_spool.id,
-        tag_id: if add_spool.tag_id.is_empty() {
-            Vec::new()
-        } else {
-            vec![add_spool.tag_id]
-        },
+        tag_id,
         material_type: add_spool.material,
         material_subtype: add_spool.subtype,
         color_name: add_spool.color_name,


### PR DESCRIPTION
There are minor changes here to support the web app hooking to do full spool adding, mostly just the ability to edit the tag ids (and specify multiple).    We also expose the bambu spool names as its required to get the same style naming you get when adding from the console.


The bulk of the changes are in the web-ui.  

[inventory-a3daa0d-Added NFC hooks for spool additions and editing the tag ids.patch](https://github.com/user-attachments/files/31862057/inventory-a3daa0d-Added.NFC.hooks.for.spool.additions.and.editing.the.tag.ids.patch)


This adds two new global functions to the webui:

onNFCTagScanned(uid);
onNFCManufacturerTagRead(uid, Sku, ManufacturerId, ColorCode, WeightGrams, diameter, MaterialType, DetailedType);


These entrypoints allow for reporting when just a raw uid is scanned or if a full bambu tag is read.


The first thing the website then does is check if the UID is known, if so just shows the card for that spool (just as if they had scanned the tag, had it open the browser, etc).

If it is not found then it either shows a soft toast that that UID is not known (if its just a random nfc tag scanned) or for bambu:

Does a search for the manufacturer/filament type/color to show any existing spools with the same properties (would allow you to quickly increase your stock count for example).

Has a message at the top asking if you want to add a spool from that tag (while also telling you the info from that spool)


If you do add a spool it automatically adds the tag ID to the record so you don't need to link it later.


Screenshot for when a bambu tag is scanned but it is not known, shows matching spools (same color/type)  and also the banner at the top to allow adding a spool matching what was specified.

<img width="351" height="715" alt="image" src="https://github.com/user-attachments/assets/03ed8cc4-f597-4619-b6b2-da2c5d14b070" />

clicking add new auto populates all the spool info:
<img width="346" height="706" alt="image" src="https://github.com/user-attachments/assets/a8832b56-f01a-488b-aacd-082a34ae7d5d" />

If a UID tag is scanned but its just a UID so no spool info read it will search against our database if we know the uid it will show its card:
<img width="354" height="716" alt="image" src="https://github.com/user-attachments/assets/e1900db7-663d-4340-8238-0f2e98e2d7b5" />


if its not a known tag it will show a toast at the bottom (so you dont have to do anything with it to continue)

<img width="350" height="716" alt="image" src="https://github.com/user-attachments/assets/8f8d86cf-2a00-42a4-bfaa-49daf648d362" />

